### PR TITLE
Rename uuid to conform with extension guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ cd gnome-shell-extension-openafs
 GNOME extensions should be placed in a specific folder:
 
 ```bash
-mkdir -p ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs
-cp -v -r * ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/
+mkdir -p ~/.local/share/gnome-shell/extensions/openafs-client@openafs.org
+cp -v -r * ~/.local/share/gnome-shell/extensions/openafs-client@openafs.org/
 ```
 
 
@@ -80,7 +80,7 @@ cp -v -r * ~/.local/share/gnome-shell/extensions/gnome-shell-extension-openafs/
 Use GNOME Extensions App (GUI) or terminal:
 
 ```bash
-gnome-extensions enable gnome-shell-extension-openafs
+gnome-extensions enable "openafs-client@openafs.org"
 ```
 
 ### 5️⃣ Test the Extension

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "gnome-shell-extension-openafs",
-  "description": "Displays OpenAFS token status in the GNOME panel",
-  "uuid": "gnome-shell-extension-openafs",
+  "description": "Manage the OpenAFS client in the GNOME panel",
+  "uuid": "openafs-client@openafs.org",
   "shell-version": [
     "46"
   ]


### PR DESCRIPTION
The extension guideline state the extension uuid should be in the form <name>@<domian> to avoid conflicts.

    https://gjs.guide/extensions/overview/anatomy.html#required-fields

Rename the uuid to "openafs-client@openafs.org" to to conform with these guidelines.  Update the installation instructions, since the installation path is based on the uuid.